### PR TITLE
Fix scaling issues with smaller windows

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -8,10 +8,12 @@ body img {
   height: 62px;
   width: 56px;
 }
-main{
+main {
   display: flex;
   justify-content: center;
   margin-top: 80px;
+  margin-left: 10%;
+  margin-right: 10%;
 }
 p {
   font-size: 20px;
@@ -22,7 +24,8 @@ header {
   background-color: #88C6ED;
   box-shadow: 0px 4px 4px grey;
   display: flex;
-  min-width: 500px;
+  margin: 0px auto;
+  min-width: 800px;
   padding: 30px;
   padding-left: 75px;
   padding-right: 85px;
@@ -42,7 +45,7 @@ nav a {
   color: white;
   text-decoration: none;
 }
-#slogan{
+#slogan {
   color: #1984c7;
   font-size: 24px;
   margin-right: auto;
@@ -51,15 +54,16 @@ nav a {
 /* index.html */
 #about-covid {
   margin-left: 60px;
-  max-width: 30%;
+  max-width: 35%;
 }
-#about-covid h1{
+#about-covid h1 {
   color: #1984c7;
 }
-#precautions{
+#precautions {
   display: grid;
-  grid-template-columns: 300px 300px;
+  grid-auto-rows: 0.2fr;
   grid-gap: 35px 100px;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
   justify-content: right;
   margin-left: 135px;
   padding-right: 38px;


### PR DESCRIPTION
Used the repeat(auto-fit) property to scale the grid columns to window size available, in turn, fixing the issue with site not displaying the left side of \#about-covid and the right side of the header not extending to the right side on larger window sizes.

Made other margin and width adjustments to imitate the original intended design.